### PR TITLE
Fix NSToolbar identifier for older macOS versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
-# 1.9.0
+## 1.9.1
+- Add identifier to `DefaultToolbar` to fix assertion failure on macOS 10.15 and 12.x (thanks to [@cbenhagen](https://github.com/cbenhagen)).
+
+## 1.9.0
 - Add `setWindowMinSize` and `setWindowMaxSize` methods to `WindowManipulator` to allow setting the minimum and maximum window size (thanks to [@defuncart](https://github.com/defuncart)).
 
-# 1.8.5
+## 1.8.5
 - Prevent `_titlebarHeight` from being set to a negative value when drag resizing the window (thanks to [@CodeEagle](https://github.com/CodeEagle)).
 
 ## 1.8.4

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   appkit_ui_element_colors: 711e7a2aa027790964e6fd90c78a666efe631432
-  FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
+  FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   macos_window_utils: 23f54331a0fd51eea9e0ed347253bf48fd379d1d
 
 PODFILE CHECKSUM: 500e4707112a5f11963bc198135953cdebb6d50c

--- a/macos/macos_window_utils/Sources/macos_window_utils/MainFlutterWindowManipulator.swift
+++ b/macos/macos_window_utils/Sources/macos_window_utils/MainFlutterWindowManipulator.swift
@@ -424,7 +424,7 @@ public class MainFlutterWindowManipulator {
         if #available(macOS 10.13, *) {
             switch (toolbarName) {
             case "DefaultToolbar":
-                let newToolbar = NSToolbar()
+                let newToolbar = NSToolbar(identifier: "DefaultToolbar")
                 
                 newToolbar.allowsUserCustomization = false
                 newToolbar.allowsExtensionItems = false

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: macos_window_utils
 description:
   macos_window_utils is a Flutter package that provides a set of methods for
   modifying the NSWindow of a Flutter application on macOS.
-version: 1.9.0
+version: 1.9.1
 repository: https://github.com/Adrian-Samoticha/macos_window_utils.dart
 
 environment:


### PR DESCRIPTION
Add identifier to DefaultToolbar to fix assertion failure on macOS 10.15 and 12.x:

  *** Assertion failure in -[NSToolbar setAllowsUserCustomization:], NSToolbar.m:1379
  Customizable toolbars require unique toolbarIdentifiers. Please use initWithIdentifier: with a unique identifier.